### PR TITLE
Fixed Branch name list

### DIFF
--- a/Gi7/Views/RepositoryView.xaml
+++ b/Gi7/Views/RepositoryView.xaml
@@ -63,6 +63,11 @@
                                     <TextBlock Text="{Binding Name}" />
                                 </DataTemplate>
                             </toolkit:ListPicker.ItemTemplate>
+                            <toolkit:ListPicker.FullModeItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Name}" FontSize="30" Padding="0,8" />
+                                </DataTemplate>
+                            </toolkit:ListPicker.FullModeItemTemplate>
                         </toolkit:ListPicker>
                         <TextBlock Text="Download" VerticalAlignment="Center" FontSize="42.667" />
                         <Button Content="Get a Zip" Tap="OpenContextMenu" >


### PR DESCRIPTION
On the Repository Detail Page I can switch through the branches, but the name is broken. The Link is still working.

You should open a Repo wich has a lot of branches.

Fix for Isue  michelsalib/Gi7#36
