### PR TITLE
Initializing Octokit connection in AuthenticateUser

### DIFF
--- a/Gi7.Client/GithubService.cs
+++ b/Gi7.Client/GithubService.cs
@@ -68,6 +68,11 @@ namespace Gi7.Client
             Username = username;
             _password = password;
 
+            connection = new Connection(new ProductHeaderValue("Gi7"))
+            {
+                Credentials = new Credentials(username, password)
+            };
+
             var request = new UserRequest();
 
             Load(request, r =>
@@ -75,11 +80,6 @@ namespace Gi7.Client
                 // set storage
                 isolatedStorageSettings["username"] = username;
                 isolatedStorageSettings["password"] = password;
-
-                connection = new Connection(new ProductHeaderValue("Gi7"))
-                {
-                    Credentials = new Credentials(username, password)
-                };
 
                 IsAuthenticated = true;
             });


### PR DESCRIPTION
When running AuthenticateUser we can initialize Octokit connection unattached to user load because the IsolatedStorageSettings already have correct user login stored.